### PR TITLE
Added missing parentheses for plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,9 +540,9 @@ module.exports = {
     },
   },
   plugins: [
-    require('@mertasan/tailwindcss-variables'){
+    require('@mertasan/tailwindcss-variables')({
       colorVariables: true
-    }
+    })
   ]
 }
 ```
@@ -662,9 +662,9 @@ module.exports = {
     },
   },
   plugins: [
-    require('@mertasan/tailwindcss-variables'){
+    require('@mertasan/tailwindcss-variables')({
       colorVariables: true,
-    }
+    })
   ]
 }
 ```
@@ -705,10 +705,10 @@ module.exports = {
     },
   },
   plugins: [
-    require('@mertasan/tailwindcss-variables'){
+    require('@mertasan/tailwindcss-variables')({
       colorVariables: true,
       forceRGB: true,
-    }
+    })
   ]
 }
 ```
@@ -755,13 +755,13 @@ module.exports = {
     },
   },
   plugins: [
-    require('@mertasan/tailwindcss-variables'){
+    require('@mertasan/tailwindcss-variables')({
       colorVariables: true,
       extendColors: {
         blue: 'var(--colors-blue)',
         red: 'var(--colors-red)',
       }
-    }
+    })
   ]
 }
 ```
@@ -826,14 +826,14 @@ module.exports = {
     },
   },
   plugins: [
-    require('@mertasan/tailwindcss-variables'){
+    require('@mertasan/tailwindcss-variables')({
       colorVariables: true,
       forceRGB: true,
       extendColors: {
         blue: 'var(--colors-blue)',
         red: 'var(--colors-red)',
       }
-    }
+    })
   ]
 }
 ```


### PR DESCRIPTION
In the documentation, there was some examples that was missing parentheses for passing options to the plugin via `require('@mertasan/tailwindcss-variables')`